### PR TITLE
Fix CUDA version inconsistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM nvidia/cuda:12.9.0-devel-ubuntu22.04
-# FROM nvidia/cuda:12.4.0-devel-ubuntu22.04
+FROM nvidia/cuda:12.4.0-devel-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
@@ -16,8 +15,7 @@ RUN apt-get update && apt-get install -y \
   && apt-get clean \
   && pip3 install --upgrade pip \
   && pip3 install --no-cache-dir \
-  torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu128 \
-  # torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu124 \
+  torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu124 \
   numpy \
   jupyter \
   jupyterlab \


### PR DESCRIPTION
## Summary
- CUDAベースイメージとPyTorchのCUDAバージョンの不整合を修正
- ベースイメージをCUDA 12.4.0に統一してPyTorchのcu124インデックスと一致させる

## Changes
- ベースイメージを `nvidia/cuda:12.9.0-devel-ubuntu22.04` から `nvidia/cuda:12.4.0-devel-ubuntu22.04` に変更
- PyTorchインストール時のCUDAインデックスをcu124に統一
- 不要なコメント行を削除

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)